### PR TITLE
Fix attr update on Node objects

### DIFF
--- a/embedding_utils.py
+++ b/embedding_utils.py
@@ -1,0 +1,18 @@
+from observed_dict_rs import Vertex
+
+
+def attach_embeddings_from_meta(vertex: Vertex) -> None:
+    """Propagate embeddings stored in ``vertex.meta`` to their nodes.
+
+    The vertex must have ``embedding`` and ``embedding_ids`` entries in
+    ``vertex.meta``. They are typically collected via a callback when
+    nodes are added.
+    """
+    embeddings = vertex.meta.get("embedding")
+    node_ids = vertex.meta.get("embedding_ids")
+    if embeddings is None or node_ids is None:
+        raise ValueError("vertex.meta must contain 'embedding' and 'embedding_ids'")
+
+    for e, node_id in zip(embeddings, node_ids):
+        node = vertex.get_node(node_id)
+        node.attr_list_append("embeddings", e)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+
+try:
+    from observed_dict_rs import Vertex
+except Exception as e:  # pragma: no cover - optional build step
+    import pytest
+    pytest.skip(f"observed_dict_rs module unavailable: {e}", allow_module_level=True)
+
+from embedding_utils import attach_embeddings_from_meta
+
+
+def add_embeddings(vertex, node):
+    if "embedding" not in vertex.meta:
+        vertex.meta["embedding"] = []
+        vertex.meta["embedding_ids"] = []
+    if "embedding" in node.attr:
+        vertex.meta["embedding"].append(node.attr["embedding"])
+        vertex.meta["embedding_ids"].append(node.id)
+    return True
+
+
+def test_attach_embeddings_from_meta():
+    v = Vertex()
+    v.on_node_add_callbacks.append(add_embeddings)
+    v.add_node("node1", {"embedding": [1, 2, 3]})
+    v.add_node("node2", {"embedding": [2, 1, 3]})
+
+    attach_embeddings_from_meta(v)
+
+    assert v.get_node("node1").attr["embeddings"] == [[1, 2, 3]]
+    assert v.get_node("node2").attr["embeddings"] == [[2, 1, 3]]
+
+
+def test_attr_helpers():
+    v = Vertex()
+    node = v.add_node("n", {})
+
+    node.attr_set("foo", 1)
+    assert node.attr_get("foo") == 1
+
+    node.attr_list_append("bar", 5)
+    node.attr_list_append("bar", 6)
+    assert node.attr_get("bar") == [5, 6]


### PR DESCRIPTION
## Summary
- expose helper methods on `Node` for getting/setting attributes
- update embedding utility to use the new `attr_list_append`
- adjust regression tests for optional native module and cover helpers

## Testing
- `pytest tests/test_embeddings.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff66bf9948320adea58f9be6086ca