### PR TITLE
Add parallel BFS and benchmark

### DIFF
--- a/ironweaver/src/vertex/algorithms/mod.rs
+++ b/ironweaver/src/vertex/algorithms/mod.rs
@@ -4,8 +4,10 @@ mod shortest_path_bfs;
 mod expand;
 mod filter;
 mod random_walks;
+mod parallel_bfs;
 
 pub use shortest_path_bfs::shortest_path_bfs;
 pub use expand::expand;
 pub use filter::filter;
 pub use random_walks::random_walks;
+pub use parallel_bfs::parallel_bfs;

--- a/ironweaver/src/vertex/algorithms/parallel_bfs.rs
+++ b/ironweaver/src/vertex/algorithms/parallel_bfs.rs
@@ -1,0 +1,88 @@
+// vertex/algorithms/parallel_bfs.rs
+
+use pyo3::prelude::*;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use rayon::prelude::*;
+
+use crate::{Node, Edge};
+use super::super::core::Vertex;
+
+/// Perform a parallel breadth-first search starting from `root_node_id`.
+///
+/// This implementation explores each BFS frontier in parallel using
+/// `rayon` to distribute work across threads. Python objects are accessed
+/// under the GIL on each thread.
+pub fn parallel_bfs(
+    vertex: &Vertex,
+    py: Python<'_>,
+    root_node_id: String,
+    max_depth: Option<usize>
+) -> PyResult<Py<Vertex>> {
+    use std::collections::HashSet;
+
+    // Validate root existence
+    if !vertex.nodes.contains_key(&root_node_id) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            format!("Root node with id '{}' not found", root_node_id)
+        ));
+    }
+
+    // Shared structures across threads
+    let visited = Arc::new(Mutex::new(HashSet::<String>::new()));
+    let found = Arc::new(Mutex::new(HashMap::<String, Py<Node>>::new()));
+    let nodelist = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    // Seed with the root node
+    Python::with_gil(|gil| {
+        if let Some(node) = vertex.nodes.get(&root_node_id) {
+            found.lock().unwrap().insert(root_node_id.clone(), node.clone_ref(gil));
+        }
+    });
+    visited.lock().unwrap().insert(root_node_id.clone());
+    nodelist.lock().unwrap().push(root_node_id.clone());
+
+    let mut frontier = vec![root_node_id];
+    let mut depth = 0usize;
+
+    while !frontier.is_empty() {
+        if let Some(max_d) = max_depth {
+            if depth >= max_d { break; }
+        }
+
+        let next_frontier = Arc::new(Mutex::new(Vec::<String>::new()));
+        frontier.par_iter().for_each(|node_id| {
+            Python::with_gil(|gil| {
+                if let Some(node) = vertex.nodes.get(node_id) {
+                    let node_ref = node.bind(gil);
+                    if let Ok(edges) = node_ref.getattr("edges").and_then(|e| e.extract::<Vec<Py<Edge>>>()) {
+                        for edge in edges {
+                            if let Ok(to_node) = edge.bind(gil).getattr("to_node").and_then(|o| o.extract::<Py<Node>>()) {
+                                if let Ok(to_id) = to_node.bind(gil).getattr("id").and_then(|o| o.extract::<String>()) {
+                                    let mut visited_lock = visited.lock().unwrap();
+                                    if !visited_lock.contains(&to_id) {
+                                        visited_lock.insert(to_id.clone());
+                                        drop(visited_lock);
+
+                                        found.lock().unwrap().insert(to_id.clone(), to_node.clone_ref(gil));
+                                        nodelist.lock().unwrap().push(to_id.clone());
+                                        next_frontier.lock().unwrap().push(to_id);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        frontier = next_frontier.lock().unwrap().clone();
+        depth += 1;
+    }
+
+    let result_nodes = Arc::try_unwrap(found).unwrap().into_inner().unwrap();
+    let path = Arc::try_unwrap(nodelist).unwrap().into_inner().unwrap();
+    let result_vertex = Vertex::from_nodes_with_path(py, result_nodes, path)?;
+    Py::new(py, result_vertex)
+}
+

--- a/ironweaver/src/vertex/core.rs
+++ b/ironweaver/src/vertex/core.rs
@@ -369,4 +369,17 @@ impl Vertex {
     ) -> PyResult<Py<PyList>> {
         algorithms::random_walks(self, py, start_node_id, max_length, min_length, num_attempts, allow_revisit, include_edge_types, edge_type_field)
     }
+
+    /// Parallel breadth-first search starting from ``root_node_id``.
+    /// When the graph is large, using this method can provide better performance
+    /// by exploring each BFS frontier concurrently.
+    #[pyo3(signature = (root_node_id, max_depth=None))]
+    fn parallel_bfs(
+        &self,
+        py: Python<'_>,
+        root_node_id: String,
+        max_depth: Option<usize>
+    ) -> PyResult<Py<Vertex>> {
+        algorithms::parallel_bfs(self, py, root_node_id, max_depth)
+    }
 }

--- a/performance_results/parallel_bfs_benchmark.py
+++ b/performance_results/parallel_bfs_benchmark.py
@@ -1,0 +1,67 @@
+"""Benchmark serial vs parallel BFS implementations.
+
+This script constructs linear graphs of varying sizes and records
+execution times for both the existing serial BFS (via ``Node.bfs``)
+and the new ``Vertex.parallel_bfs`` method. Results are written to
+``performance_results/parallel_bfs_comparison.csv``.
+"""
+
+import csv
+import datetime
+import time
+
+from ironweaver import Vertex
+
+
+def build_graph(size: int) -> Vertex:
+    g = Vertex()
+    for i in range(size):
+        g.add_node(f"n{i}", {})
+    for i in range(size - 1):
+        g.add_edge(f"n{i}", f"n{i+1}", {})
+    return g
+
+
+def run_benchmark(sizes):
+    results = []
+    for size in sizes:
+        g = build_graph(size)
+        root = g.get_node("n0")
+
+        # Serial BFS using Node.bfs
+        start = time.perf_counter()
+        root.bfs(depth=None)
+        serial_time = time.perf_counter() - start
+
+        # Parallel BFS using Vertex.parallel_bfs
+        start = time.perf_counter()
+        g.parallel_bfs("n0")
+        parallel_time = time.perf_counter() - start
+
+        timestamp = datetime.datetime.now().isoformat()
+        results.append({
+            "timestamp": timestamp,
+            "graph_size": size,
+            "serial_time": serial_time,
+            "parallel_time": parallel_time,
+        })
+    return results
+
+
+def save_csv(results, path):
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["timestamp", "graph_size", "serial_time", "parallel_time"],
+        )
+        writer.writeheader()
+        for row in results:
+            writer.writerow(row)
+
+
+if __name__ == "__main__":
+    sizes = [100, 500, 1000]
+    results = run_benchmark(sizes)
+    save_csv(results, "parallel_bfs_comparison.csv")
+    for r in results:
+        print(r)


### PR DESCRIPTION
## Summary
- implement new `parallel_bfs` algorithm leveraging rayon
- expose `Vertex.parallel_bfs` to call the algorithm
- export the algorithm in the `algorithms` module
- add a benchmark script comparing serial vs parallel BFS

## Testing
- `pytest -q`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6841ce56dab88320bbf7bf643008fd79