### PR TITLE
Add parallel BFS support

### DIFF
--- a/ironweaver/src/vertex/algorithms/mod.rs
+++ b/ironweaver/src/vertex/algorithms/mod.rs
@@ -4,8 +4,10 @@ mod shortest_path_bfs;
 mod expand;
 mod filter;
 mod random_walks;
+mod parallel_bfs;
 
 pub use shortest_path_bfs::shortest_path_bfs;
 pub use expand::expand;
 pub use filter::filter;
 pub use random_walks::random_walks;
+pub use parallel_bfs::parallel_bfs;

--- a/ironweaver/src/vertex/algorithms/parallel_bfs.rs
+++ b/ironweaver/src/vertex/algorithms/parallel_bfs.rs
@@ -1,0 +1,130 @@
+use pyo3::prelude::*;
+use std::collections::{HashMap, HashSet};
+use crate::{Node, Edge};
+use super::super::core::Vertex;
+use rayon::prelude::*;
+
+pub fn parallel_bfs(
+    vertex: &Vertex,
+    py: Python<'_>,
+    start_node_id: String,
+    target_node_id: String,
+    max_depth: Option<usize>
+) -> PyResult<Py<Vertex>> {
+    // Ensure start and target exist
+    if !vertex.nodes.contains_key(&start_node_id) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            format!("Start node with id '{}' not found", start_node_id)
+        ));
+    }
+    if !vertex.nodes.contains_key(&target_node_id) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            format!("Target node with id '{}' not found", target_node_id)
+        ));
+    }
+
+    // If start is target, return single-node vertex
+    if start_node_id == target_node_id {
+        if let Some(node) = vertex.nodes.get(&start_node_id) {
+            let mut map = HashMap::new();
+            map.insert(start_node_id.clone(), node.clone_ref(py));
+            return Py::new(py, Vertex::from_nodes(py, map));
+        }
+    }
+
+    let mut visited = HashSet::<String>::new();
+    let mut parents = HashMap::<String, String>::new();
+    let mut current_level = vec![start_node_id.clone()];
+    visited.insert(start_node_id.clone());
+    let mut depth = 0usize;
+
+    while !current_level.is_empty() {
+        if let Some(max_d) = max_depth {
+            if depth >= max_d {
+                break;
+            }
+        }
+
+        // Collect neighbors of current level in parallel
+        let neighbors: Vec<(String, String)> = current_level
+            .par_iter()
+            .flat_map(|node_id| {
+                let node_id = node_id.clone();
+                Python::with_gil(|gil| {
+                    vertex.nodes.get(&node_id)
+                        .map(|node| {
+                            let node_ref = node.bind(gil);
+                            let edges: Vec<Py<Edge>> = node_ref.getattr("edges")
+                                .ok()
+                                .and_then(|o| o.extract().ok())
+                                .unwrap_or_default();
+                            edges.into_iter().filter_map(|edge| {
+                                let edge_ref = edge.bind(gil);
+                                let to_node: Option<Py<Node>> = edge_ref.getattr("to_node").ok().and_then(|o| o.extract().ok());
+                                to_node.and_then(|n| {
+                                    let r = n.bind(gil);
+                                    r.getattr("id").ok().and_then(|o| o.extract::<String>().ok()).map(|id| (id, node_id.clone()))
+                                })
+                            }).collect::<Vec<(String, String)>>()
+                        })
+                        .unwrap_or_default()
+                })
+            })
+            .collect();
+
+        let mut next_level = Vec::new();
+        for (child, parent) in neighbors {
+            if !visited.contains(&child) {
+                visited.insert(child.clone());
+                parents.insert(child.clone(), parent);
+                if child == target_node_id {
+                    // reconstruct path
+                    let mut path_ids = Vec::new();
+                    let mut current = child.clone();
+                    path_ids.push(current.clone());
+                    while let Some(p) = parents.get(&current) {
+                        path_ids.push(p.clone());
+                        current = p.clone();
+                    }
+                    let path_set: HashSet<String> = path_ids.iter().cloned().collect();
+                    let mut path_nodes = HashMap::new();
+                    for pid in &path_ids {
+                        if let Some(orig) = vertex.nodes.get(pid) {
+                            let orig_ref = orig.bind(py);
+                            let attr: HashMap<String, Py<PyAny>> = orig_ref.getattr("attr").ok().and_then(|o| o.extract().ok()).unwrap_or_default();
+                            let orig_edges: Vec<Py<Edge>> = orig_ref.getattr("edges").ok().and_then(|o| o.extract().ok()).unwrap_or_default();
+                            let mut filtered = Vec::new();
+                            for e in orig_edges {
+                                let e_ref = e.bind(py);
+                                if let Ok(to_node) = e_ref.getattr("to_node") {
+                                    if let Ok(to_py) = to_node.extract::<Py<Node>>() {
+                                        let to_ref = to_py.bind(py);
+                                        if let Ok(tid) = to_ref.getattr("id") {
+                                            if let Ok(tid_str) = tid.extract::<String>() {
+                                                if path_set.contains(&tid_str) {
+                                                    filtered.push(e.clone_ref(py));
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            let new_node = Py::new(py, Node::new(pid.clone(), Some(attr), Some(filtered)))?;
+                            path_nodes.insert(pid.clone(), new_node);
+                        }
+                    }
+                    let result_vertex = Vertex::from_nodes(py, path_nodes);
+                    return Py::new(py, result_vertex);
+                }
+                next_level.push(child);
+            }
+        }
+        current_level = next_level;
+        depth += 1;
+    }
+
+    Err(pyo3::exceptions::PyValueError::new_err(
+        format!("Target node '{}' not reachable from '{}' within max_depth {:?}",
+                target_node_id, start_node_id, max_depth)
+    ))
+}

--- a/ironweaver/src/vertex/core.rs
+++ b/ironweaver/src/vertex/core.rs
@@ -301,6 +301,20 @@ impl Vertex {
         algorithms::shortest_path_bfs(self, py, root_node_id, target_node_id, max_depth)
     }
 
+    /// Parallel Breadth-First Search between source and target nodes.
+    /// This variant uses rayon to process each BFS level concurrently and can
+    /// be faster on very large graphs.
+    #[pyo3(signature = (root_node_id, target_node_id, max_depth=None))]
+    fn parallel_bfs(
+        &self,
+        py: Python<'_>,
+        root_node_id: String,
+        target_node_id: String,
+        max_depth: Option<usize>
+    ) -> PyResult<Py<Vertex>> {
+        algorithms::parallel_bfs(self, py, root_node_id, target_node_id, max_depth)
+    }
+
     /// Expand the current vertex by adding neighbor nodes from a source vertex
     /// 
     /// Args:

--- a/performance_results/benchmark_parallel_bfs.py
+++ b/performance_results/benchmark_parallel_bfs.py
@@ -1,0 +1,33 @@
+import time
+from ironweaver import Vertex
+
+
+def build_linear_graph(n):
+    v = Vertex()
+    for i in range(n):
+        v.add_node(f"n{i}", {"value": i})
+    for i in range(n - 1):
+        v.add_edge(f"n{i}", f"n{i+1}", None)
+    return v
+
+
+def run_bench(size=5000):
+    v = build_linear_graph(size)
+    start_id = "n0"
+    target_id = f"n{size-1}"
+
+    t0 = time.perf_counter()
+    v.shortest_path_bfs(start_id, target_id)
+    serial_time = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    v.parallel_bfs(start_id, target_id)
+    parallel_time = time.perf_counter() - t0
+
+    print(f"Graph size: {size}")
+    print(f"serial bfs:   {serial_time:.6f}s")
+    print(f"parallel bfs: {parallel_time:.6f}s")
+
+
+if __name__ == "__main__":
+    run_bench()


### PR DESCRIPTION
## Summary
- implement `parallel_bfs` using rayon
- expose new `Vertex.parallel_bfs()` method
- export algorithm in `mod.rs`
- add benchmark script to compare parallel vs serial BFS

## Testing
- `cargo check -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d3b1a1b8832098ce21a2c64aa2df