### PR TITLE
Improve Rust BFS and random walk

### DIFF
--- a/ironweaver/src/vertex/algorithms/random_walks.rs
+++ b/ironweaver/src/vertex/algorithms/random_walks.rs
@@ -2,17 +2,16 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyList;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use crate::{Node, Edge};
 use super::super::core::Vertex;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 
-// Structure to hold a walk with optional edge types
 #[derive(Clone)]
 struct Walk {
     nodes: Vec<String>,
-    edges: Vec<String>, // Edge types between nodes
+    edges: Vec<String>,
 }
 
 pub fn random_walks(
@@ -26,72 +25,76 @@ pub fn random_walks(
     include_edge_types: Option<bool>,
     edge_type_field: Option<String>
 ) -> PyResult<Py<PyList>> {
-    // Validate start node exists
     if !vertex.nodes.contains_key(&start_node_id) {
         return Err(pyo3::exceptions::PyValueError::new_err(
             format!("Start node with id '{}' not found", start_node_id)
         ));
-    }    let min_len = min_length.unwrap_or(1);
+    }
+
+    let min_len = min_length.unwrap_or(1);
     let allow_revisit_nodes = allow_revisit.unwrap_or(false);
     let include_edges = include_edge_types.unwrap_or(false);
     let type_field = edge_type_field.unwrap_or_else(|| "type".to_string());
-    
-    // Validate parameters
+
     if max_length == 0 {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "max_length must be greater than 0"
         ));
     }
-    
     if min_len > max_length {
         return Err(pyo3::exceptions::PyValueError::new_err(
             "min_length cannot be greater than max_length"
         ));
     }
-    
+
+    // Build adjacency list with optional edge types
+    let mut adjacency: HashMap<String, Vec<(String, Option<String>)>> = HashMap::new();
+    for (id, node) in &vertex.nodes {
+        let node_ref = node.bind(py);
+        let edges: Vec<Py<Edge>> = node_ref.getattr("edges")?.extract().unwrap_or_default();
+        let mut neigh = Vec::new();
+        for edge in edges {
+            let edge_ref = edge.bind(py);
+            let to_node: Py<Node> = edge_ref.getattr("to_node")?.extract()?;
+            let to_id = to_node.bind(py).getattr("id")?.extract::<String>()?;
+            let e_type = if include_edges {
+                edge_ref
+                    .getattr("attr")
+                    .ok()
+                    .and_then(|attr| attr.get_item(&type_field).ok())
+                    .and_then(|val| val.extract::<String>().ok())
+            } else { None };
+            neigh.push((to_id, e_type));
+        }
+        adjacency.insert(id.clone(), neigh);
+    }
+
     let mut all_walks = Vec::new();
-    let mut rng = thread_rng();    // Perform multiple random walk attempts
+    let mut rng = thread_rng();
     for _ in 0..num_attempts {
-        if let Some(walk) = perform_simple_random_walk(
-            vertex,
-            py,
-            start_node_id.clone(),
-            max_length,
-            allow_revisit_nodes,
-            include_edges,
-            &type_field,
-            &mut rng
-        )? {
-            // Only add walks that meet minimum length requirement
+        if let Some(walk) = perform_walk(&adjacency, &start_node_id, max_length, allow_revisit_nodes, include_edges, &mut rng) {
             if walk.nodes.len() >= min_len {
                 all_walks.push(walk);
             }
         }
-    }    // Remove duplicates
+    }
 
-    // Remove duplicates
     let mut unique_walks = Vec::new();
-    let mut seen_walks = HashSet::new();
-    
+    let mut seen = HashSet::new();
     for walk in all_walks {
-        // Create a string representation for comparison
-        let walk_key = if include_edges {
+        let key = if include_edges {
             format!("{}|{}", walk.nodes.join(","), walk.edges.join(","))
         } else {
             walk.nodes.join(",")
         };
-        
-        if !seen_walks.contains(&walk_key) {
-            seen_walks.insert(walk_key);
+        if seen.insert(key) {
             unique_walks.push(walk);
         }
     }
 
-    // Convert to Python list
     let result = PyList::empty(py);
     for walk in unique_walks {
         if include_edges {
-            // Return list of [node, edge_type, node, edge_type, ...] format
             let py_walk = PyList::empty(py);
             for i in 0..walk.nodes.len() {
                 py_walk.append(&walk.nodes[i])?;
@@ -101,107 +104,50 @@ pub fn random_walks(
             }
             result.append(py_walk)?;
         } else {
-            // Return list of nodes only
             let py_walk = PyList::empty(py);
-            for node_id in walk.nodes {
-                py_walk.append(node_id)?;
+            for id in walk.nodes {
+                py_walk.append(id)?;
             }
             result.append(py_walk)?;
         }
     }
-    
+
     Ok(result.into())
 }
 
-// Simple random walk function that embraces randomness without backtracking
-fn perform_simple_random_walk(
-    vertex: &Vertex,
-    py: Python<'_>,
-    start_node_id: String,
+fn perform_walk(
+    adjacency: &HashMap<String, Vec<(String, Option<String>)>>,
+    start: &str,
     max_length: usize,
     allow_revisit: bool,
     include_edge_types: bool,
-    edge_type_field: &str,
     rng: &mut rand::rngs::ThreadRng
-) -> PyResult<Option<Walk>> {    let mut walk_nodes = Vec::new();
-    let mut walk_edges = Vec::new();
+) -> Option<Walk> {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
     let mut visited = HashSet::new();
-    let mut current_node_id = start_node_id;
+    let mut current = start.to_string();
 
-    // Start the walk
     for _ in 0..max_length {
-        // Add current node to walk
-        walk_nodes.push(current_node_id.clone());
-        
-        // Track visited nodes if revisiting is not allowed
+        nodes.push(current.clone());
         if !allow_revisit {
-            visited.insert(current_node_id.clone());
+            visited.insert(current.clone());
         }
-
-        // Get the current node
-        let current_node = match vertex.nodes.get(&current_node_id) {
-            Some(node) => node,
-            None => break, // Node not found, end walk
-        };
-
-        // Get edges from current node
-        let node_ref = current_node.bind(py);
-        let edges: Vec<Py<Edge>> = match node_ref.getattr("edges") {
-            Ok(edges_attr) => match edges_attr.extract() {
-                Ok(edges) => edges,
-                Err(_) => break, // No edges or extraction failed, end walk
-            },
-            Err(_) => break, // No edges attribute, end walk
-        };
-
-        // Collect valid next nodes and their corresponding edge types
-        let mut valid_next_options = Vec::new();
-        for edge in edges {
-            let edge_ref = edge.bind(py);
-            if let Ok(to_node) = edge_ref.getattr("to_node") {
-                if let Ok(to_node_py) = to_node.extract::<Py<Node>>() {
-                    let to_node_ref = to_node_py.bind(py);
-                    if let Ok(to_id) = to_node_ref.getattr("id") {
-                        if let Ok(to_id_str) = to_id.extract::<String>() {
-                            // Include node if revisiting is allowed OR if we haven't visited it
-                            if allow_revisit || !visited.contains(&to_id_str) {
-                                // Get edge type if needed
-                                let edge_type = if include_edge_types {
-                                    edge_ref.getattr("attr")
-                                        .ok()
-                                        .and_then(|attr| attr.get_item(edge_type_field).ok())
-                                        .and_then(|type_val| type_val.extract::<String>().ok())
-                                        .unwrap_or_else(|| "unknown".to_string())
-                                } else {
-                                    String::new()
-                                };
-                                
-                                valid_next_options.push((to_id_str, edge_type));
-                            }
-                        }
-                    }
-                }
+        let neighbors = adjacency.get(&current)?;
+        let mut options = Vec::new();
+        for (to_id, edge_type) in neighbors {
+            if allow_revisit || !visited.contains(to_id) {
+                options.push((to_id.clone(), edge_type.clone()));
             }
         }
-
-        // If no valid next nodes, end the walk
-        if valid_next_options.is_empty() {
-            break;
+        if options.is_empty() { break; }
+        let (next, e_type) = options.choose(rng)?.clone();
+        if include_edge_types {
+            edges.push(e_type.unwrap_or_else(|| "unknown".to_string()));
         }
-
-        // Randomly choose next option - this is where the true randomness happens
-        if let Some((next_node, edge_type)) = valid_next_options.choose(rng) {
-            if include_edge_types {
-                walk_edges.push(edge_type.clone());
-            }
-            current_node_id = next_node.clone();
-        } else {
-            break; // Should not happen, but handle gracefully
-        }
+        current = next;
     }
 
-    Ok(Some(Walk {
-        nodes: walk_nodes,
-        edges: walk_edges,
-    }))
+    Some(Walk { nodes, edges })
 }
+

--- a/ironweaver/src/vertex/algorithms/shortest_path_bfs.rs
+++ b/ironweaver/src/vertex/algorithms/shortest_path_bfs.rs
@@ -1,7 +1,7 @@
 // vertex/algorithms/shortest_path_bfs.rs
 
 use pyo3::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use crate::{Node, Edge};
 use super::super::core::Vertex;
 
@@ -12,126 +12,102 @@ pub fn shortest_path_bfs(
     target_node_id: String,
     max_depth: Option<usize>
 ) -> PyResult<Py<Vertex>> {
-    use std::collections::{VecDeque, HashMap as StdHashMap};
-    
-    // Get the root node
-    let root_node = vertex.nodes.get(&root_node_id)
-        .ok_or_else(|| pyo3::exceptions::PyValueError::new_err(
+    // Validate nodes exist
+    if !vertex.nodes.contains_key(&root_node_id) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
             format!("Root node with id '{}' not found", root_node_id)
-        ))?
-        .clone_ref(py);
-    
-    // Check if target exists in the graph
+        ));
+    }
     if !vertex.nodes.contains_key(&target_node_id) {
         return Err(pyo3::exceptions::PyValueError::new_err(
             format!("Target node with id '{}' not found", target_node_id)
         ));
     }
-    
-    // Check if root is the target
+
+    // Special case: root == target
     if root_node_id == target_node_id {
         let mut path_nodes = HashMap::<String, Py<Node>>::new();
-        
-        // Create a new node with no edges (since it's just a single node path)
-        let original_node_ref = root_node.bind(py);
-        let attr: HashMap<String, Py<PyAny>> = original_node_ref.getattr("attr")?.extract().unwrap_or_default();
-        let new_node = Py::new(py, Node::new(root_node_id.clone(), Some(attr), Some(Vec::new())))?;
-        path_nodes.insert(root_node_id, new_node);
-        
+        if let Some(orig_node) = vertex.nodes.get(&root_node_id) {
+            let orig_ref = orig_node.bind(py);
+            let attr: HashMap<String, Py<PyAny>> = orig_ref.getattr("attr")?.extract().unwrap_or_default();
+            let new_node = Py::new(py, Node::new(root_node_id.clone(), Some(attr), Some(Vec::new())))?;
+            path_nodes.insert(root_node_id.clone(), new_node);
+        }
         let result_vertex = Vertex::from_nodes(py, path_nodes);
         return Py::new(py, result_vertex);
     }
-    
-    let mut visited = std::collections::HashSet::<String>::new();
-    let mut queue = VecDeque::new();
-    let mut parent_map = StdHashMap::<String, String>::new();
-    
-    // Initialize queue with root node
-    visited.insert(root_node_id.clone());
-    queue.push_back((root_node, 0));
-    
-    // Perform BFS from the root node
-    while let Some((current_node, current_depth)) = queue.pop_front() {
-        // Check depth limit
-        if let Some(max_d) = max_depth {
-            if current_depth >= max_d {
-                continue;
-            }
-        }
 
-        // Get edges from current node
-        let current_ref = current_node.bind(py);
-        let edges: Vec<Py<Edge>> = current_ref.getattr("edges")?.extract()?;
-        let current_id = current_ref.getattr("id")?.extract::<String>()?;
-        
+    // Build adjacency list once to avoid Python lookups during search
+    let mut adjacency: HashMap<String, Vec<String>> = HashMap::new();
+    for (id, node) in &vertex.nodes {
+        let node_ref = node.bind(py);
+        let edges: Vec<Py<Edge>> = node_ref.getattr("edges")?.extract().unwrap_or_default();
+        let mut neigh = Vec::new();
         for edge in edges {
             let edge_ref = edge.bind(py);
-            let to_node_actual: Py<Node> = edge_ref.getattr("to_node")?.extract()?;
-            let to_node_ref = to_node_actual.bind(py);
-            let to_id = to_node_ref.getattr("id")?.extract::<String>()?;
-            
-            // If not visited, mark and enqueue
-            if !visited.contains(&to_id) {
-                visited.insert(to_id.clone());
-                parent_map.insert(to_id.clone(), current_id.clone());
-                queue.push_back((to_node_actual, current_depth + 1));
-                
-                // If this is our target, reconstruct the path
-                if to_id == target_node_id {
-                    // Reconstruct the path from target back to root
-                    let mut path_ids = Vec::new();
-                    let mut current = target_node_id.clone();
-                    path_ids.push(current.clone());
-                    
-                    // Trace back through parents to build the path
-                    while let Some(parent) = parent_map.get(&current) {
-                        path_ids.push(parent.clone());
-                        current = parent.clone();
-                    }
-                    
-                    // Create new vertex with path nodes, filtering edges to only include path connections
-                    let mut path_nodes = HashMap::<String, Py<Node>>::new();
-                    let path_set: std::collections::HashSet<String> = path_ids.iter().cloned().collect();
-                    
-                    for path_id in &path_ids {
-                        if let Some(original_node) = vertex.nodes.get(path_id) {
-                            let original_node_ref = original_node.bind(py);
-                            
-                            // Get original attributes
-                            let attr: HashMap<String, Py<PyAny>> = original_node_ref.getattr("attr")?.extract().unwrap_or_default();
-                            
-                            // Get original edges and filter to only include edges to other path nodes
-                            let original_edges: Vec<Py<Edge>> = original_node_ref.getattr("edges")?.extract().unwrap_or_default();
-                            let mut filtered_edges = Vec::new();
-                            
-                            for edge in original_edges {
-                                let edge_ref = edge.bind(py);
-                                let edge_to_node: Py<Node> = edge_ref.getattr("to_node")?.extract()?;
-                                let edge_to_node_ref = edge_to_node.bind(py);
-                                let edge_to_id = edge_to_node_ref.getattr("id")?.extract::<String>()?;
-                                
-                                // Only include edge if target is also in the path
-                                if path_set.contains(&edge_to_id) {
-                                    filtered_edges.push(edge.clone_ref(py));
-                                }
-                            }
-                            
-                            // Create new node with filtered edges
-                            let new_node = Py::new(py, Node::new(path_id.clone(), Some(attr), Some(filtered_edges)))?;
-                            path_nodes.insert(path_id.clone(), new_node);
+            let to_node: Py<Node> = edge_ref.getattr("to_node")?.extract()?;
+            let to_id = to_node.bind(py).getattr("id")?.extract::<String>()?;
+            neigh.push(to_id);
+        }
+        adjacency.insert(id.clone(), neigh);
+    }
+
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+    let mut parent_map: HashMap<String, String> = HashMap::new();
+
+    visited.insert(root_node_id.clone());
+    queue.push_back((root_node_id.clone(), 0usize));
+
+    while let Some((current_id, current_depth)) = queue.pop_front() {
+        if let Some(max_d) = max_depth {
+            if current_depth >= max_d { continue; }
+        }
+        if let Some(neighbors) = adjacency.get(&current_id) {
+            for to_id in neighbors {
+                if !visited.contains(to_id) {
+                    visited.insert(to_id.clone());
+                    parent_map.insert(to_id.clone(), current_id.clone());
+                    if to_id == &target_node_id {
+                        let mut path_ids = Vec::new();
+                        let mut cur = target_node_id.clone();
+                        path_ids.push(cur.clone());
+                        while let Some(parent) = parent_map.get(&cur) {
+                            path_ids.push(parent.clone());
+                            cur = parent.clone();
                         }
+                        let path_set: HashSet<String> = path_ids.iter().cloned().collect();
+                        let mut path_nodes = HashMap::<String, Py<Node>>::new();
+                        for pid in &path_ids {
+                            if let Some(original_node) = vertex.nodes.get(pid) {
+                                let orig_ref = original_node.bind(py);
+                                let attr: HashMap<String, Py<PyAny>> = orig_ref.getattr("attr")?.extract().unwrap_or_default();
+                                let original_edges: Vec<Py<Edge>> = orig_ref.getattr("edges")?.extract().unwrap_or_default();
+                                let mut filtered_edges = Vec::new();
+                                for edge in original_edges {
+                                    let edge_ref = edge.bind(py);
+                                    let to_node: Py<Node> = edge_ref.getattr("to_node")?.extract()?;
+                                    let to_id = to_node.bind(py).getattr("id")?.extract::<String>()?;
+                                    if path_set.contains(&to_id) {
+                                        filtered_edges.push(edge.clone_ref(py));
+                                    }
+                                }
+                                let new_node = Py::new(py, Node::new(pid.clone(), Some(attr), Some(filtered_edges)))?;
+                                path_nodes.insert(pid.clone(), new_node);
+                            }
+                        }
+                        let result_vertex = Vertex::from_nodes(py, path_nodes);
+                        return Py::new(py, result_vertex);
                     }
-                    
-                    let result_vertex = Vertex::from_nodes(py, path_nodes);
-                    return Py::new(py, result_vertex);
+                    queue.push_back((to_id.clone(), current_depth + 1));
                 }
             }
         }
     }
-    
-    // Target not found within max_depth
+
     Err(pyo3::exceptions::PyValueError::new_err(
-        format!("Target node '{}' not reachable from '{}' within max_depth {:?}", 
+        format!("Target node '{}' not reachable from '{}' within max_depth {:?}",
                 target_node_id, root_node_id, max_depth)
     ))
 }
+


### PR DESCRIPTION
## Summary
- rewrite `shortest_path_bfs` to convert the graph to an adjacency list once
- rewrite `random_walks` to run walks completely in Rust
- avoid repeated Python attribute access during searches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841df14cef083209dd5609f882a2b4a