### PR TITLE
Improve ObservedDictionary callbacks

### DIFF
--- a/ironweaver/src/observed_dictionary.rs
+++ b/ironweaver/src/observed_dictionary.rs
@@ -1,6 +1,7 @@
 // observed_dictionary.rs
 
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use std::collections::HashMap;
 
 #[pyclass]
@@ -25,22 +26,39 @@ impl ObservedDictionary {
         }
     }
 
-    fn __setitem__(&mut self, py: Python<'_>, key: String, value: Py<PyAny>) {
+    fn __setitem__(&mut self, py: Python<'_>, key: String, value: Py<PyAny>) -> PyResult<()> {
         let old_value = self.dict.get(&key).map(|v| v.clone_ref(py));
-        self.dict.insert(key.clone(), value.clone_ref(py));
-        if let Some(callbacks) = self.callbacks.get(&key) {
-            for cb in callbacks {
-                let _ = cb.call1(
-                    py,
-                    (
-                        self.node.as_ref().map(|n| n.clone_ref(py)),
-                        key.clone(),
-                        value.clone_ref(py),
-                        old_value.as_ref().map(|v| v.clone_ref(py)), // Clone the Py<PyAny> inside Option
-                    ),
-                );
+
+        // Determine whether the value actually changed using Python's equality
+        let mut changed = true;
+        if let Some(ref old) = old_value {
+            let eq_obj = old
+                .bind(py)
+                .rich_compare(value.bind(py), CompareOp::Eq)?;
+            if eq_obj.is_truthy()? {
+                changed = false;
             }
         }
+
+        self.dict.insert(key.clone(), value.clone_ref(py));
+
+        if changed {
+            if let Some(callbacks) = self.callbacks.get(&key) {
+                for cb in callbacks {
+                    cb.call1(
+                        py,
+                        (
+                            self.node.as_ref().map(|n| n.clone_ref(py)),
+                            key.clone(),
+                            value.clone_ref(py),
+                            old_value.as_ref().map(|v| v.clone_ref(py)),
+                        ),
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn __getitem__(&self, py: Python<'_>, key: String) -> PyResult<Py<PyAny>> {

--- a/tests/test_observed_dictionary.py
+++ b/tests/test_observed_dictionary.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+
+try:
+    from ironweaver import ObservedDictionary
+except Exception as e:  # pragma: no cover - optional build step
+    import pytest
+    pytest.skip(f"ironweaver module unavailable: {e}", allow_module_level=True)
+
+
+class Recorder:
+    def __init__(self):
+        self.calls = 0
+        self.args = []
+
+    def cb(self, node, key, value, old_value):
+        self.calls += 1
+        self.args.append((node, key, value, old_value))
+
+
+def test_setitem_callback_on_change():
+    rec = Recorder()
+    d = ObservedDictionary(None, {"foo": [rec.cb]})
+    d["foo"] = 1
+    assert rec.calls == 1
+    assert rec.args[0][1:] == ("foo", 1, None)
+
+    d["foo"] = 1
+    assert rec.calls == 1  # no new call when value unchanged
+
+    d["foo"] = 2
+    assert rec.calls == 2
+    assert rec.args[1][1:] == ("foo", 2, 1)
+


### PR DESCRIPTION
## Summary
- add test for ObservedDictionary callback behavior
- skip callback invocation when value is unchanged

## Testing
- `pip install maturin`
- `pip install -e ./ironweaver`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842df1f9f7883208c7c9b39d8b5c597