### PR TITLE
Add f16 serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ graph.save_to_json("my_graph.json")
 
 # Save to binary format (more efficient for large graphs)
 graph.save_to_binary("my_graph.bin")
+# Or use half precision floats to reduce file size
+graph.save_to_binary_f16("my_graph_f16.bin")
 
 # Load from file
 loaded_graph = Vertex.load_from_json("my_graph.json")
@@ -171,6 +173,7 @@ metadata = graph.get_metadata() -> dict
 # Persistence
 graph.save_to_json(file_path: str)
 graph.save_to_binary(file_path: str)
+graph.save_to_binary_f16(file_path: str)
 loaded = Vertex.load_from_json(file_path: str) -> Vertex
 loaded = Vertex.load_from_binary(file_path: str) -> Vertex
 ```

--- a/ironweaver/Cargo.toml
+++ b/ironweaver/Cargo.toml
@@ -13,4 +13,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.3"
 chrono = { version = "0.4", features = ["serde"] }
+half = { version = "2.2", features = ["serde"] }
 rand = "0.8"

--- a/ironweaver/src/vertex/core.rs
+++ b/ironweaver/src/vertex/core.rs
@@ -230,6 +230,12 @@ impl Vertex {
         serialization::save_to_binary(self, py, file_path)
     }
 
+    /// Save the graph to a binary file using f16 precision for floats
+    #[pyo3(text_signature = "(self, file_path)")]
+    fn save_to_binary_f16(&self, py: Python<'_>, file_path: String) -> PyResult<()> {
+        serialization::save_to_binary_f16(self, py, file_path)
+    }
+
     /// Load a graph from a JSON file
     /// 
     /// Args:

--- a/ironweaver/src/vertex/serialization.rs
+++ b/ironweaver/src/vertex/serialization.rs
@@ -22,6 +22,15 @@ pub fn save_to_binary(vertex: &Vertex, py: Python<'_>, file_path: String) -> PyR
     Ok(())
 }
 
+pub fn save_to_binary_f16(vertex: &Vertex, py: Python<'_>, file_path: String) -> PyResult<()> {
+    let serializable_graph = SerializableGraph::from_vertex(py, vertex)?;
+    serializable_graph.save_to_binary_f16(&file_path)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+            format!("Failed to save graph to binary: {}", e)
+        ))?;
+    Ok(())
+}
+
 pub fn load_from_json(py: Python<'_>, file_path: String) -> PyResult<Py<Vertex>> {
     let serializable_graph = SerializableGraph::load_from_json(&file_path)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(

--- a/tests/test_serialization_large.py
+++ b/tests/test_serialization_large.py
@@ -25,13 +25,18 @@ def test_large_serialization(tmp_path):
     v = build_large_graph(node_count)
     json_file = tmp_path / "graph.json"
     bin_file = tmp_path / "graph.bin"
+    bin_file_f16 = tmp_path / "graph_f16.bin"
 
     v.save_to_json(str(json_file))
     v.save_to_binary(str(bin_file))
+    v.save_to_binary_f16(str(bin_file_f16))
 
     v_json = Vertex.load_from_json(str(json_file))
     assert v_json.node_count() == node_count
 
     v_bin = Vertex.load_from_binary(str(bin_file))
     assert v_bin.node_count() == node_count
+
+    v_bin_f16 = Vertex.load_from_binary(str(bin_file_f16))
+    assert v_bin_f16.node_count() == node_count
 


### PR DESCRIPTION
## Summary
- support half-precision floats for binary serialization
- document `save_to_binary_f16`
- expose `save_to_binary_f16` on `Vertex`
- test binary roundtrip with f16

## Testing
- `pip install -e ./ironweaver`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f8360624832085d4851c83408aff