### PR TITLE
Add LGF parser

### DIFF
--- a/lgf_parser.py
+++ b/lgf_parser.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from ironweaver import Vertex
+
+
+def _parse_value(value: str):
+    value = value.strip()
+    if value.isdigit():
+        return int(value)
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    if (value.startswith("\"") and value.endswith("\"")) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    if value.lower() in {"true", "false"}:
+        return value.lower() == "true"
+    return value
+
+
+def parse_igf3(text: str) -> Vertex:
+    """Parse LGF text into a :class:`Vertex` graph.
+
+    Parameters
+    ----------
+    text:
+        Input text in LGF format.
+
+    Returns
+    -------
+    Vertex
+        The parsed graph.
+    """
+    graph = Vertex()
+    current_node = None
+    current_edge = None
+    edge_indent = 0
+
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped == "#":
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip())
+
+        if indent == 0:
+            parts = stripped.split()
+            node_id = parts[0]
+            labels = parts[1:]
+            attrs = {"labels": labels} if labels else {}
+            if graph.has_node(node_id):
+                current_node = graph.get_node(node_id)
+            else:
+                graph.add_node(node_id, attrs)
+                current_node = graph.get_node(node_id)
+            current_edge = None
+            continue
+
+        if stripped.startswith("->"):
+            rest = stripped[2:].strip()
+            target, typ = rest.split(None, 1)
+            if not graph.has_node(target):
+                graph.add_node(target, {})
+            current_edge = graph.add_edge(current_node.id, target, {"type": typ})
+            edge_indent = indent
+            continue
+
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        value = _parse_value(value)
+
+        if current_edge is not None and indent > edge_indent:
+            attrs = dict(current_edge.attr)
+            attrs[key] = value
+            current_edge.attr = attrs
+        else:
+            current_node.attr_set(key, value)
+            current_edge = None
+
+    return graph

--- a/tests/test_lgf_parser.py
+++ b/tests/test_lgf_parser.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+
+try:
+    from ironweaver import Vertex
+except Exception as e:
+    import pytest
+    pytest.skip(f"ironweaver module unavailable: {e}", allow_module_level=True)
+
+from lgf_parser import parse_igf3
+
+
+EXAMPLE = """\
+n1 Person
+  name = Alice
+  age = 30
+  -> n2 KNOWS
+    since = 2020
+#
+n2 Person
+  name = Bob
+"""
+
+
+def test_parse_igf3():
+    g = parse_igf3(EXAMPLE)
+    assert isinstance(g, Vertex)
+    assert g.node_count() == 2
+
+    n1 = g.get_node("n1")
+    assert n1.attr_get("name") == "Alice"
+    assert n1.attr_get("age") == 30
+    assert n1.attr_get("labels") == ["Person"]
+
+    n2 = g.get_node("n2")
+    assert n2.attr_get("name") == "Bob"
+
+    edges = n1.edges
+    assert len(edges) == 1
+    e = edges[0]
+    assert e.attr["type"] == "KNOWS"
+    assert e.to_node.id == "n2"
+    assert e.attr["since"] == 2020


### PR DESCRIPTION
## Summary
- implement `parse_igf3` to parse indentation-based LGF format
- add unit test covering parsing example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9b0913cc8320bcd2cb2ac2e0bea1