### PR TITLE
Support imports in LGF parser

### DIFF
--- a/python/ironweaver/__init__.py
+++ b/python/ironweaver/__init__.py
@@ -2,7 +2,7 @@
 from ._ironweaver import Vertex, Node, Edge, Path, ObservedDictionary
 
 # Import the Python LGF parser
-from .lgf_parser import parse_lgf
+from .lgf_parser import parse_lgf, parse_lgf_file
 
 # Export all public components
 __all__ = [
@@ -11,5 +11,6 @@ __all__ = [
     "Edge",
     "Path",
     "ObservedDictionary",
-    "parse_lgf"
+    "parse_lgf",
+    "parse_lgf_file",
 ]

--- a/tests/test_lgf_parser.py
+++ b/tests/test_lgf_parser.py
@@ -1,16 +1,17 @@
-import os
 import sys
+from pathlib import Path
 
-ROOT = os.path.dirname(os.path.dirname(__file__))
-sys.path.insert(0, ROOT)
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "python"))
 
 try:
     from ironweaver import Vertex
-except Exception as e:
+except Exception as e:  # pragma: no cover - handled via pytest skip
     import pytest
+
     pytest.skip(f"ironweaver module unavailable: {e}", allow_module_level=True)
 
-from ironweaver.lgf_parser import parse_igf3
+from ironweaver.lgf_parser import parse_lgf, parse_lgf_file
 
 
 EXAMPLE = """\
@@ -25,8 +26,8 @@ n2 Person
 """
 
 
-def test_parse_igf3():
-    g = parse_igf3(EXAMPLE)
+def test_parse_lgf():
+    g = parse_lgf(EXAMPLE)
     assert isinstance(g, Vertex)
     assert g.node_count() == 2
 
@@ -44,3 +45,24 @@ def test_parse_igf3():
     assert e.attr["type"] == "KNOWS"
     assert e.to_node.id == "n2"
     assert e.attr["since"] == 2020
+
+
+def test_parse_lgf_with_import(tmp_path):
+    imported = tmp_path / "other.lgf"
+    imported.write_text("n2 Person\n  name = Bob\n")
+
+    base = tmp_path / "base.lgf"
+    base.write_text(
+        f"import({imported.name})\n"
+        "n1 Person\n"
+        "  name = Alice\n"
+        "  age = 30\n"
+        "  -> n2 KNOWS\n"
+        "    since = 2020\n"
+    )
+
+    g = parse_lgf_file(str(base))
+    assert isinstance(g, Vertex)
+    assert g.node_count() == 2
+    n2 = g.get_node("n2")
+    assert n2.attr_get("name") == "Bob"


### PR DESCRIPTION
## Summary
- allow LGF text to import other LGF files via `import(path)`
- add `parse_lgf_file` helper and expose it in the package API
- cover import behaviour with new tests

## Testing
- `pip install maturin`
- `pip install -e .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac3d4e6ccc8320ab64d6606df49122