### PR TITLE
Add flexible vertex filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ plt.show()
 
 ```python
 # Create a subgraph and expand it by exploring neighbors
-filtered_graph = graph.filter(['node2'])  # Start with just node2
+filtered_graph = graph.filter(ids=['node2'])  # Start with just node2
 expanded = filtered_graph.expand(graph, depth=1)  # Expand 1 level
 
 print(f"Original nodes: {graph.keys()}")
@@ -167,7 +167,7 @@ edge = graph.add_edge(from_id: str, to_id: str, attr: dict = None) -> Edge
 # Algorithms
 path = graph.shortest_path_bfs(start: str, end: str, max_depth: int = None) -> Vertex
 expanded = graph.expand(source: Vertex, depth: int = 1) -> Vertex
-filtered = graph.filter(node_ids: List[str]) -> Vertex
+filtered = graph.filter(**filters) -> Vertex  # filters can include 'ids', 'id', or attribute=value pairs
 
 # Conversion and analysis
 nx_graph = graph.to_networkx() -> networkx.DiGraph

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+PYTHON_DIR = os.path.join(ROOT, "python")
+sys.path.insert(0, PYTHON_DIR)
+
+try:
+    from ironweaver import Vertex
+except Exception as e:  # pragma: no cover - optional build step
+    import pytest
+    pytest.skip(f"ironweaver module unavailable: {e}", allow_module_level=True)
+
+
+def build_graph():
+    v = Vertex()
+    v.add_node("n1", {"attribute": "is_this"})
+    v.add_node("n2", {"attribute": "other"})
+    v.add_node("n3", {"attribute": "is_this"})
+    v.add_edge("n1", "n2", {})
+    v.add_edge("n2", "n3", {})
+    return v
+
+
+def test_filter_ids():
+    v = build_graph()
+    filtered = v.filter(ids=["n1", "n3"])
+    assert set(filtered.keys()) == {"n1", "n3"}
+
+
+def test_filter_id_single():
+    v = build_graph()
+    filtered = v.filter(id="n2")
+    assert set(filtered.keys()) == {"n2"}
+
+
+def test_filter_attribute():
+    v = build_graph()
+    filtered = v.filter(attribute="is_this")
+    assert set(filtered.keys()) == {"n1", "n3"}


### PR DESCRIPTION
## Summary
- accept arbitrary keyword arguments in `Vertex.filter`, interpreting `ids` or `id` specially and treating other key/value pairs as attribute filters
- document generic filter usage in README

## Testing
- `pip install maturin`
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac434c87a88320a11486120bb2c251